### PR TITLE
Support egulias/email-validator:^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=7.4",
-    "egulias/email-validator": "^2.0|^3.1",
+    "egulias/email-validator": "^2.0|^3.1|^4.0",
     "symfony/polyfill-iconv": "^1.0",
     "symfony/polyfill-mbstring": "^1.0",
     "symfony/polyfill-intl-idn": "^1.10"


### PR DESCRIPTION
Supporting egulias/email-validator:^4.0 should work without additional changes.
This would allow to use this fork in Drupal 10.1.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | #...
| License       | MIT


<!-- Replace this comment by the description of your issue. -->
